### PR TITLE
Load default scripts on duel creation

### DIFF
--- a/server_room.cpp
+++ b/server_room.cpp
@@ -191,6 +191,8 @@ void ServerRoom::StartDuel(bool result)
 	spectatorTeamObserver.Deinitialize();
 
 	duel = std::make_shared<Duel>(ci, rnd());
+	duel->PreloadScript("constant.lua");
+	duel->PreloadScript("utility.lua");
 	std::weak_ptr<Duel> weakDuel = duel;
 	firstTeamObserver.SetDuel(weakDuel);
 	secondTeamObserver.SetDuel(weakDuel);


### PR DESCRIPTION
After this change to the core https://github.com/edo9300/ygopro-core/commit/df60f5882dd01cc19580996ccc85c36967dca961, the constant and utility scripts will no longer be loaded directly by the library, but instead it'll be up to the program hosting the duel to do so. This requires this pull request https://github.com/DyXel/ygopen/pull/3 to be merged first to have access to the preloadScript function.