### PR TITLE
Feature update: config file loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# YGOpen Legacy Server
+
+The YGOpen project aims to create a free-as-in-freedom, cleanly-engineered Yu-Gi-Oh! Official Card Game simulator, complete with client and server support. This server supports [EDOPro](https://github.com/edo9300/ygopro) clients and dynamically links to [that core](https://github.com/edo9300/ygopro-core).
+
+## Prerequisites
+
+- Git (or you can download the zip from GitHub)
+- [premake5](https://premake.github.io/download.html#v5): extract this into the working directory
+- Platform C++ toolchain
+  - Windows: [Visual Studio](https://visualstudio.microsoft.com/)
+  - macOS: GCC (Clang does NOT support C++14/C++17 standard library)
+  - Linux: GCC or Clang
+
+- On macOS, we use [Homebrew](https://brew.sh/) to get dependencies. Install `gcc` with `brew install gcc`
+- On Windows, set up [`vcpkg`](https://github.com/microsoft/vcpkg)
+
+## Dependencies
+
+Build [ocgcore](https://github.com/edo9300/ygopro-core) as a shared library and put it in the folder where you will move the server executable.
+
+On Linux, get these dependencies from your package manager or build from source: `asio nlohmann-json sqlite3`.
+
+On Windows, invoke vcpkg to build dependencies from source: `vcpkg install --triplet x86-windows-static asio nlohmann-json sqlite3`.
+
+On macOS, install dependencies with `brew install asio nlohmann-json sqlite3`.
+
+## Build
+
+On Linux, do `./premake5 gmake2 && make -Cbuild` for a debug build, or `make -Cbuild config=release` for a release build.
+
+On Windows, do `./premake5.exe vs2017` or `./premake5.exe vs2019` to create the solution files and then build from the generated Visual Studio `.sln` file in `build`.
+
+On macOS, do `./premake5 gmake2 && make -Cbuild CC=gcc-9 CXX=g++-9` for a GCC debug build, assuming you installed GCC with brew.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ On Linux, do `./premake5 gmake2 && make -Cbuild` for a debug build. Specify `con
 On Windows, do `./premake5.exe vs2017` or `./premake5.exe vs2019` to create the solution files and then build from the generated Visual Studio `.sln` file in `build`.
 
 On macOS, do `./premake5 gmake2 && make -Cbuild CXX=g++-9` for a GCC debug build, assuming you installed GCC with brew.
+
+## Legal
+
+This project is released under the GNU Affero General Public License 3.0. The EDOPro core script engine is released under the MIT License. 
+
+Yu-Gi-Oh! is a trademark of Shueisha and Konami. The YGOpen project is not affiliated or endorsed by Shueisha or Konami.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The YGOpen project aims to create a free-as-in-freedom, cleanly-engineered Yu-Gi
 - Platform C++ toolchain
   - Windows: [Visual Studio](https://visualstudio.microsoft.com/)
   - macOS: GCC (Clang does NOT support C++14/C++17 standard library)
-  - Linux: GCC or Clang
+  - Linux: GCC 8+ or Clang 5+
 
 - On macOS, we use [Homebrew](https://brew.sh/) to get dependencies. Install `gcc` with `brew install gcc`
 - On Windows, set up [`vcpkg`](https://github.com/microsoft/vcpkg)
@@ -26,8 +26,8 @@ On macOS, install dependencies with `brew install asio nlohmann-json sqlite3`.
 
 ## Build
 
-On Linux, do `./premake5 gmake2 && make -Cbuild` for a debug build, or `make -Cbuild config=release` for a release build.
+On Linux, do `./premake5 gmake2 && make -Cbuild` for a debug build. Specify `config=release` for a release build and make sure to set your compiler with `CXX=`
 
 On Windows, do `./premake5.exe vs2017` or `./premake5.exe vs2019` to create the solution files and then build from the generated Visual Studio `.sln` file in `build`.
 
-On macOS, do `./premake5 gmake2 && make -Cbuild CC=gcc-9 CXX=g++-9` for a GCC debug build, assuming you installed GCC with brew.
+On macOS, do `./premake5 gmake2 && make -Cbuild CXX=g++-9` for a GCC debug build, assuming you installed GCC with brew.

--- a/config.cpp
+++ b/config.cpp
@@ -8,15 +8,15 @@ namespace Legacy
 
 namespace ServerConfig {
 
-nlohmann::json read_config(std::string filename) {
+nlohmann::json Get(std::string filename) {
 	std::ifstream config_file(filename);
 	nlohmann::json config = nlohmann::json::parse(config_file);
 	return config;
 }
 
-nlohmann::json get_or_default(std::string filename) {
+nlohmann::json GetOrDefault(std::string filename) {
 	if (std::filesystem::exists(filename)) {
-		return read_config(filename);
+		return Get(filename);
 	}
 	else {
 		std::ofstream config_file(filename);
@@ -25,7 +25,7 @@ nlohmann::json get_or_default(std::string filename) {
 	}
 }
 
-std::shared_ptr<std::vector<std::string>> expand_directories(nlohmann::json j) {
+std::shared_ptr<std::vector<std::string>> ExpandDirectories(nlohmann::json j) {
 	const auto& array = j.get<std::vector<std::string>>();
 	auto result = std::make_shared<std::vector<std::string>>();
 	for (const auto& str : array) {

--- a/config.cpp
+++ b/config.cpp
@@ -1,0 +1,50 @@
+#include "config.hpp"
+#include <fstream>
+
+namespace YGOpen
+{
+namespace Legacy
+{
+
+namespace ServerConfig {
+
+nlohmann::json read_config(std::string filename) {
+    std::ifstream config_file(filename);
+    nlohmann::json config = nlohmann::json::parse(config_file);
+    return config;
+}
+
+nlohmann::json get_or_default(std::string filename) {
+    if (std::filesystem::exists(filename)) {
+        return read_config(filename);
+    }
+    else {
+        std::ofstream config_file(filename);
+        config_file << DEFAULT_CONFIG.dump(4);
+        return DEFAULT_CONFIG;
+    }
+}
+
+std::shared_ptr<std::vector<std::string>> expand_directories(nlohmann::json j) {
+    const auto& array = j.get<std::vector<std::string>>();
+    auto result = std::make_shared<std::vector<std::string>>();
+    for (const auto& str : array) {
+        if (std::filesystem::exists(str)) {
+            if (std::filesystem::is_directory(str)) {
+                auto listing = std::filesystem::recursive_directory_iterator(str);
+                std::transform(begin(listing), end(listing), std::back_inserter(*result), [](const std::filesystem::directory_entry& file) {
+                    return file.path().string();
+                });
+            }
+            else {
+                result->push_back(str);
+            }
+        }
+    }
+    return result;
+}
+
+} // namespace ServerConfig
+
+} // namespace Legacy
+} // namespace YGOpen

--- a/config.cpp
+++ b/config.cpp
@@ -9,39 +9,39 @@ namespace Legacy
 namespace ServerConfig {
 
 nlohmann::json read_config(std::string filename) {
-    std::ifstream config_file(filename);
-    nlohmann::json config = nlohmann::json::parse(config_file);
-    return config;
+	std::ifstream config_file(filename);
+	nlohmann::json config = nlohmann::json::parse(config_file);
+	return config;
 }
 
 nlohmann::json get_or_default(std::string filename) {
-    if (std::filesystem::exists(filename)) {
-        return read_config(filename);
-    }
-    else {
-        std::ofstream config_file(filename);
-        config_file << DEFAULT_CONFIG.dump(4);
-        return DEFAULT_CONFIG;
-    }
+	if (std::filesystem::exists(filename)) {
+		return read_config(filename);
+	}
+	else {
+		std::ofstream config_file(filename);
+		config_file << DEFAULT_CONFIG.dump(4);
+		return DEFAULT_CONFIG;
+	}
 }
 
 std::shared_ptr<std::vector<std::string>> expand_directories(nlohmann::json j) {
-    const auto& array = j.get<std::vector<std::string>>();
-    auto result = std::make_shared<std::vector<std::string>>();
-    for (const auto& str : array) {
-        if (std::filesystem::exists(str)) {
-            if (std::filesystem::is_directory(str)) {
-                auto listing = std::filesystem::recursive_directory_iterator(str);
-                std::transform(begin(listing), end(listing), std::back_inserter(*result), [](const std::filesystem::directory_entry& file) {
-                    return file.path().string();
-                });
-            }
-            else {
-                result->push_back(str);
-            }
-        }
-    }
-    return result;
+	const auto& array = j.get<std::vector<std::string>>();
+	auto result = std::make_shared<std::vector<std::string>>();
+	for (const auto& str : array) {
+		if (std::filesystem::exists(str)) {
+			if (std::filesystem::is_directory(str)) {
+				auto listing = std::filesystem::recursive_directory_iterator(str);
+				std::transform(begin(listing), end(listing), std::back_inserter(*result), [](const std::filesystem::directory_entry& file) {
+					return file.path().string();
+				});
+			}
+			else {
+				result->push_back(str);
+			}
+		}
+	}
+	return result;
 }
 
 } // namespace ServerConfig

--- a/config.hpp
+++ b/config.hpp
@@ -11,15 +11,15 @@ namespace Legacy
 namespace ServerConfig {
 
 const nlohmann::json DEFAULT_CONFIG = R"(
-    {
-        "protocol": "tcp4",
-        "port": 44444,
-        "databases": [
-            "databases/cards.cdb",
-            "databases/cards-anime-vg-manga.cdb"
-        ],
-        "banlists": []
-    }
+	{
+		"protocol": "tcp4",
+		"port": 44444,
+		"databases": [
+			"databases/cards.cdb",
+			"databases/cards-anime-vg-manga.cdb"
+		],
+		"banlists": []
+	}
 )"_json;
 
 nlohmann::json read_config(std::string filename);
@@ -27,12 +27,12 @@ nlohmann::json read_config(std::string filename);
 nlohmann::json get_or_default(std::string filename);
 
 template<typename... T, typename = typename std::enable_if<std::conjunction<std::is_convertible<T, std::string>...>::value>::type> 
-    nlohmann::json get_or_default(std::string first, T const&... filename) {
-    if(std::filesystem::exists(first)) {
+	nlohmann::json get_or_default(std::string first, T const&... filename) {
+	if(std::filesystem::exists(first)) {
 		return read_config(first);
 	} else {
-        return get_or_default(filename...);
-    }
+		return get_or_default(filename...);
+	}
 }
 
 std::shared_ptr<std::vector<std::string>> expand_directories(nlohmann::json j);

--- a/config.hpp
+++ b/config.hpp
@@ -22,20 +22,20 @@ const nlohmann::json DEFAULT_CONFIG = R"(
 	}
 )"_json;
 
-nlohmann::json read_config(std::string filename);
+nlohmann::json Get(std::string filename);
 
-nlohmann::json get_or_default(std::string filename);
+nlohmann::json GetOrDefault(std::string filename);
 
 template<typename... T, typename = typename std::enable_if<std::conjunction<std::is_convertible<T, std::string>...>::value>::type> 
-	nlohmann::json get_or_default(std::string first, T const&... filename) {
+	nlohmann::json GetOrDefault(std::string first, T const&... filename) {
 	if(std::filesystem::exists(first)) {
-		return read_config(first);
+		return Get(first);
 	} else {
-		return get_or_default(filename...);
+		return GetOrDefault(filename...);
 	}
 }
 
-std::shared_ptr<std::vector<std::string>> expand_directories(nlohmann::json j);
+std::shared_ptr<std::vector<std::string>> ExpandDirectories(nlohmann::json j);
 
 } // namespace ServerConfig
 

--- a/config.hpp
+++ b/config.hpp
@@ -1,0 +1,45 @@
+#ifndef __YGOPEN_LEGACY_SERVER_CONFIG_HPP__
+#define __YGOPEN_LEGACY_SERVER_CONFIG_HPP__
+#include <filesystem>
+#include <nlohmann/json.hpp>
+
+namespace YGOpen
+{
+namespace Legacy
+{
+
+namespace ServerConfig {
+
+const nlohmann::json DEFAULT_CONFIG = R"(
+    {
+        "protocol": "tcp4",
+        "port": 44444,
+        "databases": [
+            "databases/cards.cdb",
+            "databases/cards-anime-vg-manga.cdb"
+        ],
+        "banlists": []
+    }
+)"_json;
+
+nlohmann::json read_config(std::string filename);
+
+nlohmann::json get_or_default(std::string filename);
+
+template<typename... T, typename = typename std::enable_if<std::conjunction<std::is_convertible<T, std::string>...>::value>::type> 
+    nlohmann::json get_or_default(std::string first, T const&... filename) {
+    if(std::filesystem::exists(first)) {
+		return read_config(first);
+	} else {
+        return get_or_default(filename...);
+    }
+}
+
+std::shared_ptr<std::vector<std::string>> expand_directories(nlohmann::json j);
+
+} // namespace ServerConfig
+
+} // namespace Legacy
+} // namespace YGOpen
+
+#endif // __YGOPEN_LEGACY_SERVER_CONFIG_HPP__

--- a/main.cpp
+++ b/main.cpp
@@ -1,14 +1,21 @@
 #include <iostream>
 #include <exception>
 #include <asio.hpp>
+#include "config.hpp"
 #include "server_acceptor.hpp"
 
 int main()
 {
+	nlohmann::json config = YGOpen::Legacy::ServerConfig::get_or_default("ygopen-srv.json", "ygopen.json", "config.json");
 	asio::io_service ioService;
-	asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v4(), 44444);
-
-	YGOpen::Legacy::ServerAcceptor sa(ioService, endpoint);
+	auto protocol = asio::ip::tcp::v4();
+	if(config["protocol"] == "tcp6") {
+		protocol = asio::ip::tcp::v6();
+	}
+	asio::ip::tcp::endpoint endpoint(protocol, static_cast<unsigned short>(config["port"]));
+	std::shared_ptr<std::vector<std::string>> databases = YGOpen::Legacy::ServerConfig::expand_directories(config["databases"]);
+	std::shared_ptr<std::vector<std::string>> banlists = YGOpen::Legacy::ServerConfig::expand_directories(config["banlists"]);
+	YGOpen::Legacy::ServerAcceptor sa(ioService, endpoint, *databases, *banlists);
 	
 	ioService.run();
 

--- a/main.cpp
+++ b/main.cpp
@@ -6,15 +6,15 @@
 
 int main()
 {
-	nlohmann::json config = YGOpen::Legacy::ServerConfig::get_or_default("ygopen-srv.json", "ygopen.json", "config.json");
+	nlohmann::json config = YGOpen::Legacy::ServerConfig::GetOrDefault("ygopen-srv.json", "ygopen.json", "config.json");
 	asio::io_service ioService;
 	auto protocol = asio::ip::tcp::v4();
 	if(config["protocol"] == "tcp6") {
 		protocol = asio::ip::tcp::v6();
 	}
 	asio::ip::tcp::endpoint endpoint(protocol, static_cast<unsigned short>(config["port"]));
-	std::shared_ptr<std::vector<std::string>> databases = YGOpen::Legacy::ServerConfig::expand_directories(config["databases"]);
-	std::shared_ptr<std::vector<std::string>> banlists = YGOpen::Legacy::ServerConfig::expand_directories(config["banlists"]);
+	std::shared_ptr<std::vector<std::string>> databases = YGOpen::Legacy::ServerConfig::ExpandDirectories(config["databases"]);
+	std::shared_ptr<std::vector<std::string>> banlists = YGOpen::Legacy::ServerConfig::ExpandDirectories(config["banlists"]);
 	YGOpen::Legacy::ServerAcceptor sa(ioService, endpoint, *databases, *banlists);
 	
 	ioService.run();

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,49 +1,49 @@
 local project_name = "ygopen-srv"
 
 workspace(project_name)
-	language("C++")
-	location("build")
-	objdir("obj")
-
-	configurations({"Debug", "Release"})
+	language "C++"
+	location "build"
+	objdir "obj"
 	startproject(project_name)
 
-	filter("action:vs*")
-		characterset("ASCII")
+	configurations {"Debug", "Release"} 
+	
+	filter "configurations:Debug"
+		symbols "On"
+		defines "_DEBUG"
+		targetdir "bin/debug"
+		runtime "Debug"
+
+	filter "configurations:Release"
+		optimize "Speed"
+		defines "_RELEASE"
+		targetdir "bin/release"
+
+	filter "action:vs*"
+		characterset "ASCII"
 		platforms { "x86", "x86_64" }
 		filter "platforms:x86"
 			architecture "x32"
 		filter "platforms:x64"
 			architecture "x64"
 
-	filter("configurations:Debug")
-		symbols("On")
-		defines("_DEBUG")
-		targetdir("bin/debug")
-		runtime "Debug"
-
-	filter("configurations:Release")
-		optimize("Speed")
-		defines("_RELEASE")
-		targetdir("bin/release")
-
-	filter("system:windows")
+	filter "system:windows"
 		defines { "WIN32", "_WIN32", "NOMINMAX" }
 
-	filter("system:macosx")
+	filter "system:macosx"
 		includedirs "/usr/local/include"
 
 project(project_name)
-	kind("ConsoleApp")
-	warnings("Extra")
-	defines("ASIO_STANDALONE")
-	files({"**.hpp", "**.cpp"})
-	staticruntime "on"
+	kind "ConsoleApp"
 	cppdialect "C++17"
+	warnings "Extra"
+	defines "ASIO_STANDALONE"
+	files { "**.hpp", "**.cpp" } 
+	staticruntime "on"
 	
-	filter("system:not windows")
-		buildoptions({"-pedantic"})
-		links({"dl", "pthread", "sqlite3"})
+	filter "system:not windows"
+		buildoptions { "-pedantic" } 
+		links { "dl", "pthread", "sqlite3" } 
 
 local function vcpkgStaticTriplet(prj)
 	premake.w('<VcpkgTriplet Condition="\'$(Platform)\'==\'Win32\'">x86-windows-static</VcpkgTriplet>')

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,8 +1,8 @@
 local project_name = "ygopen-srv"
 
 workspace(project_name)
-	location("build")
 	language("C++")
+	location("build")
 	objdir("obj")
 
 	configurations({"Debug", "Release"})
@@ -30,15 +30,19 @@ workspace(project_name)
 	filter("system:windows")
 		defines { "WIN32", "_WIN32", "NOMINMAX" }
 
+	filter("system:macosx")
+		includedirs "/usr/local/include"
+
 project(project_name)
 	kind("ConsoleApp")
 	warnings("Extra")
 	defines("ASIO_STANDALONE")
 	files({"**.hpp", "**.cpp"})
 	staticruntime "on"
-
+	cppdialect "C++17"
+	
 	filter("system:not windows")
-		buildoptions({"-pedantic", "--std=c++17"})
+		buildoptions({"-pedantic"})
 		links({"dl", "pthread", "sqlite3"})
 
 local function vcpkgStaticTriplet(prj)

--- a/server_acceptor.hpp
+++ b/server_acceptor.hpp
@@ -27,7 +27,7 @@ class ServerAcceptor
 	CoreInterface ci;
 	Banlist bl;
 	
-	bool LoadDatabases();
+	bool LoadDatabases(std::vector<std::string>& databases);
 	bool LoadBanlist();
 
 	std::vector<std::weak_ptr<ServerRoom>> rooms;
@@ -37,7 +37,7 @@ class ServerAcceptor
 	void DoSignalWait();
 	void DoAccept();
 public:
-	ServerAcceptor(asio::io_service& ioService, asio::ip::tcp::endpoint& endpoint);
+	ServerAcceptor(asio::io_service& ioService, asio::ip::tcp::endpoint& endpoint, std::vector<std::string>& databases, std::vector<std::string>& banlists);
 	~ServerAcceptor();
 };
 


### PR DESCRIPTION
- No longer hardcoded in `server_acceptor.cpp`
  - In `main.cpp`, we check for three possibilities and generate a default if none is found
  - Protocol, port, database files, and banlist files are specified in this json currently
- Add support for specifying port in config
- Add support for TCP/IPv6
- Add support for directory expansion in specifying config files (as in, all files in the specified directory will be read)
- Guarantee C++17 build on all platforms since we're using `<filesystem>`, so build with GCC on macOS
- No support for banlists yet, unused param added for further expansion
- ~~No support for UDP yet, pending `ServerAcceptor` rewrite to be generic~~

Closes #9 
